### PR TITLE
fix dashboard activity layout

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -21,3 +21,15 @@
   width: 120px;
   object-fit: cover;
 }
+
+@media screen and (min-width: 380px) {
+  .elastic_br {
+    display: none;
+  }
+}
+
+@media screen and (min-width: 768px) and (max-width: 991px){
+  .elastic_br {
+    display: block;
+  }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -15,10 +15,11 @@
             <div class="h-100 ml-3 my-auto col-xs-8">
                 <p class="my-0">
                     <a href="{{ action('ProfileController@profile', $activity['subject']) }}">{{ $activity['subject']->name === $user->name ? 'You' : $activity['subject']->name }}</a>
-                    &nbsp;{{ $activity['action'] }}&nbsp;
+                    <span>&nbsp;{{ $activity['action'] }}&nbsp;</span>
                     @if ($activity['action'] == 'followed')
                         <a href="{{ action('ProfileController@profile', $activity['object']) }}">{{ $activity['object']->name === $user->name ? 'You' : $activity['object']->name }}</a>
                     @else
+                        <br class="elastic_br">
                         <a href="{{ action('LessonController@lessonIndex') }}">{{ $activity['object']->title }}</a>
                     @endif
                 </p>

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -34,7 +34,7 @@
                     <button class="btn btn-primary w-75">Edit account</button>
                 </p></a>
                 <a href="{{ action('HomeController@wordsLearned', $user) }}">{{ $count_words_learned }} words learned</a>
-                <p class="colour-primary">{{ count($user->lessons()->get()) }} lessons Learned</p>
+                <p class="colour-primary">{{ count($user->lessons()->get()) }} lessons learned</p>
             </div>
         </div>
         


### PR DESCRIPTION
***Commands to run:***
- none

***Pre-conditions:***
- Login as any user.
- Adjust window width at dashboard page from max to min, and confirm that layout of "Activities" part would not be collapsed with any window width (like this image: https://gyazo.com/231c2201275571e9a15e2565e97a2b91).


***Expected outputs:***
-  Layout of "Activities" part at dashboard page would not be collapsed with any window width. 

***Routes:***
- your_hostname/