### PR TITLE
disable lesson retake prevention

### DIFF
--- a/app/Http/Controllers/LessonController.php
+++ b/app/Http/Controllers/LessonController.php
@@ -31,12 +31,6 @@ class LessonController extends Controller
             session()->flash($category->title, 'no contents');
             return back();
         }
-
-        //In case that user has already taken the lesson.
-        if(count(User::find(Auth::id())->lessons->where('category_id', $category->id)) !== 0) {
-            session()->flash($category->title, 'taken');
-            return back();
-        }
     
         //For storing answers to array in session. Second condition is to help duplication by page reload.
         if(session()->get('result') == NULL) {

--- a/resources/views/category.blade.php
+++ b/resources/views/category.blade.php
@@ -14,8 +14,6 @@
                     <p>{{ $category->description }}</p>
                     @if(session()->get($category->title) === 'no contents')
                         <span class="mb-3 text-info">This lesson has no contents yet</span>
-                    @elseif(session()->get($category->title) === 'taken')
-                        <span class="mb-3 text-info">You have already taken this lesson</span>
                     @endif
                     <a class="mt-auto" href="{{ route('lessonAnswer', ['category' => $category->id, 'page_number' => 0, 'correct' => 0]) }}">
                         <button class="btn btn-primary w-25">Start</button>


### PR DESCRIPTION
***Commands to run:***
- none

***Pre-conditions:***
- Login
- Go to the route and take some lesson which you've already taken. And confirm that you can take that lesson.

***Expected outputs:***
- Now user can take lessons which he has already taken.

***Routes:***
- your_hostname/category